### PR TITLE
fix the consistency with the published version

### DIFF
--- a/models/RCA.py
+++ b/models/RCA.py
@@ -83,8 +83,10 @@ class AE(nn.Module):
         _, d = x1.shape
         z1 = self.encoder1(x1)
         xhat1 = self.decoder1(z1)
-        z2 = self.encoder1(x2)
-        xhat2 = self.decoder1(z2)
+        z2 = self.encoder2(x2)
+        xhat2 = self.decoder2(z2)
+        # z2 = self.encoder1(x2)
+        # xhat2 = self.decoder1(z2)
         return z1, z2, xhat1, xhat2
 
 

--- a/trainRCA.py
+++ b/trainRCA.py
@@ -22,7 +22,7 @@ class Solver_RCA:
         training_ratio=0.8,  #  training data percentage
         max_epochs=100,  #  training epochs
         coteaching=1.0,  #  whether selects sample based on loss value
-        oe=0.0,  # how much we overestimate the ground-truth anomaly ratio
+        oe=0.0,  # how much we overestimate the ground-truth anomaly ratio'
         missing_ratio=0.0,  # missing ratio in the data
     ):
         # Data loader
@@ -155,10 +155,12 @@ class Solver_RCA:
                 loss.backward()
                 optimizer.step()
 
-            if self.beta < self.data_anomaly_ratio:
-                self.beta = min(
-                    self.data_anomaly_ratio, self.beta + self.decay_ratio
-                )
+            self.beta = max(1-self.data_anomaly_ratio,
+                            self.beta - self.data_anomaly_ratio / (self.alpha * self.max_epochs))
+            # if self.beta < self.data_anomaly_ratio:
+            #     self.beta = min(
+            #         self.data_anomaly_ratio, self.beta + self.decay_ratio
+            #     )
 
     def test(self):
         print("======================TEST MODE======================")


### PR DESCRIPTION
Dear authors,

I just read your paper published in IJCAI'21. 
This work is very promising, it provides a novel way to solve the contamination problem in the training set. It is theoretically sound and empirically shows superior results. 

I found two places in your code that are inconsistent with the published version. 
- The paper claims *two autoencoders with different initializations*, but in the source code, the `self.encoder2` and `self.decoder2` seems to be useless in the current implementation.
- the updating rule of $\beta$ in the current implementation is inconsistent with the paper (`self.alpha` is also useless as well), so I modified the decay function. 

Thanks so much for your contribution and release. 

Best regards,